### PR TITLE
Optimized/refactoring parser init

### DIFF
--- a/liteflow-core/src/main/java/com/yomahub/liteflow/core/FlowExecutor.java
+++ b/liteflow-core/src/main/java/com/yomahub/liteflow/core/FlowExecutor.java
@@ -90,7 +90,7 @@ public class FlowExecutor {
             return;
         }
 
-        List<String> sourceRulePathList = Lists.newArrayList(liteflowConfig.getRuleSource().split(",|;"));
+        List<String> sourceRulePathList = Lists.newArrayList(liteflowConfig.getRuleSource().split("[,;]"));
 
         FlowParser parser = null;
         Set<String> parserNameSet = new HashSet<>();

--- a/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/ClassParserFactory.java
+++ b/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/ClassParserFactory.java
@@ -1,0 +1,33 @@
+package com.yomahub.liteflow.parser.factory;
+
+import com.yomahub.liteflow.parser.JsonFlowParser;
+import com.yomahub.liteflow.parser.XmlFlowParser;
+import com.yomahub.liteflow.parser.YmlFlowParser;
+import com.yomahub.liteflow.spi.holder.ContextAwareHolder;
+
+/**
+ * Class文件
+ * <p>
+ *
+ * @author junjun
+ */
+public class ClassParserFactory implements FlowParserFactory {
+
+    @Override
+    public JsonFlowParser createJsonParser(String path) throws Exception {
+        Class<?> c = Class.forName(path);
+        return (JsonFlowParser) ContextAwareHolder.loadContextAware().registerBean(c);
+    }
+
+    @Override
+    public XmlFlowParser createXmlParser(String path) throws Exception {
+        Class<?> c = Class.forName(path);
+        return (XmlFlowParser) ContextAwareHolder.loadContextAware().registerBean(c);
+    }
+
+    @Override
+    public YmlFlowParser createYmlParser(String path) throws Exception {
+        Class<?> c = Class.forName(path);
+        return (YmlFlowParser) ContextAwareHolder.loadContextAware().registerBean(c);
+    }
+}

--- a/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/FlowParserFactory.java
+++ b/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/FlowParserFactory.java
@@ -1,0 +1,21 @@
+package com.yomahub.liteflow.parser.factory;
+
+import com.yomahub.liteflow.parser.JsonFlowParser;
+import com.yomahub.liteflow.parser.XmlFlowParser;
+import com.yomahub.liteflow.parser.YmlFlowParser;
+
+/**
+ * Flow Parser 工厂接口
+ * <p>
+ *
+ * @author junjun
+ */
+public interface FlowParserFactory {
+
+    JsonFlowParser createJsonParser(String path) throws Exception;
+
+    XmlFlowParser createXmlParser(String path) throws Exception;
+
+    YmlFlowParser createYmlParser(String path) throws Exception;
+
+}

--- a/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/FlowParserProvider.java
+++ b/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/FlowParserProvider.java
@@ -1,0 +1,122 @@
+package com.yomahub.liteflow.parser.factory;
+
+import cn.hutool.core.util.ReUtil;
+import cn.hutool.core.util.StrUtil;
+import com.yomahub.liteflow.core.FlowExecutor;
+import com.yomahub.liteflow.exception.ConfigErrorException;
+import com.yomahub.liteflow.exception.ErrorSupportPathException;
+import com.yomahub.liteflow.parser.ClassJsonFlowParser;
+import com.yomahub.liteflow.parser.ClassXmlFlowParser;
+import com.yomahub.liteflow.parser.ClassYmlFlowParser;
+import com.yomahub.liteflow.parser.FlowParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.yomahub.liteflow.enums.FlowParserTypeEnum.*;
+
+/**
+ * 解析器提供者
+ * <p>
+ *
+ * @author junjun
+ */
+public class FlowParserProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlowExecutor.class);
+
+    private static final String LOCAL_XML_CONFIG_REGEX = "^[\\w\\:\\-\\@\\/\\\\\\*]+\\.xml$";
+    private static final String LOCAL_JSON_CONFIG_REGEX = "^[\\w\\:\\-\\@\\/\\\\\\*]+\\.json$";
+    private static final String LOCAL_YML_CONFIG_REGEX = "^[\\w\\:\\-\\@\\/\\\\\\*]+\\.yml$";
+
+    private static final String FORMATE_XML_CONFIG_REGEX = "xml:.+";
+    private static final String FORMATE_JSON_CONFIG_REGEX = "json:.+";
+    private static final String FORMATE_YML_CONFIG_REGEX = "yml:.+";
+
+    private static final String CLASS_CONFIG_REGEX = "^\\w+(\\.\\w+)*$";
+
+    /**
+     * 根据配置的地址找到对应的解析器
+     *
+     * @param path
+     * @return
+     */
+    public static FlowParser lookup(String path) throws Exception {
+        if (isLocalConfig(path)) {
+            FlowParserFactory factory = new LocalParserFactory();
+            if (ReUtil.isMatch(LOCAL_XML_CONFIG_REGEX, path)) {
+                LOG.info("flow info loaded from local file,path={},format type={}", path, TYPE_XML.getType());
+                return factory.createXmlParser(path);
+            }
+            else if (ReUtil.isMatch(LOCAL_JSON_CONFIG_REGEX, path)) {
+                LOG.info("flow info loaded from local file,path={},format type={}", path, TYPE_JSON.getType());
+                return factory.createJsonParser(path);
+            }
+            else if (ReUtil.isMatch(LOCAL_YML_CONFIG_REGEX, path)) {
+                LOG.info("flow info loaded from local file,path={},format type={}", path, TYPE_YML.getType());
+                return factory.createYmlParser(path);
+            }
+        }
+        else if (isClassConfig(path)) {
+            FlowParserFactory factory = new ClassParserFactory();
+            Class<?> clazz = Class.forName(path);
+            if (ClassXmlFlowParser.class.isAssignableFrom(clazz)) {
+                LOG.info("flow info loaded from class config,class={},format type={}", path, TYPE_XML.getType());
+                return factory.createXmlParser(path);
+            }
+            else if (ClassJsonFlowParser.class.isAssignableFrom(clazz)) {
+                LOG.info("flow info loaded from class config,class={},format type={}", path, TYPE_JSON.getType());
+                return factory.createJsonParser(path);
+            }
+            else if (ClassYmlFlowParser.class.isAssignableFrom(clazz)) {
+                LOG.info("flow info loaded from class config,class={},format type={}", path, TYPE_YML.getType());
+                return factory.createYmlParser(path);
+            }
+            // 自定义类必须实现以上实现类，否则报错
+            String errorMsg = StrUtil.format("can't support the format {}", path);
+            throw new ErrorSupportPathException(errorMsg);
+        }
+        else if (isZKConfig(path)) {
+            FlowParserFactory factory = new ZookeeperParserFactory();
+            if (ReUtil.isMatch(FORMATE_XML_CONFIG_REGEX, path)) {
+                LOG.info("flow info loaded from Zookeeper,zkNode={},format type={}", path, TYPE_XML.getType());
+                return factory.createXmlParser(path);
+            }
+            else if (ReUtil.isMatch(FORMATE_JSON_CONFIG_REGEX, path)) {
+                LOG.info("flow info loaded from Zookeeper,zkNode={},format type={}", path, TYPE_JSON.getType());
+                return factory.createJsonParser(path);
+            }
+            else if (ReUtil.isMatch(FORMATE_YML_CONFIG_REGEX, path)) {
+                LOG.info("flow info loaded from Zookeeper,zkNode={},format type={}", path, TYPE_YML.getType());
+                return factory.createYmlParser(path);
+            }
+        }
+
+        // not found
+        throw new ConfigErrorException("parse error, please check liteflow config property");
+    }
+
+    /**
+     * 判定是否为本地文件
+     */
+    private static boolean isLocalConfig(String path) {
+        return ReUtil.isMatch(LOCAL_XML_CONFIG_REGEX, path)
+                || ReUtil.isMatch(LOCAL_JSON_CONFIG_REGEX, path)
+                || ReUtil.isMatch(LOCAL_YML_CONFIG_REGEX, path);
+    }
+
+    /**
+     * 判定是否为自定义class配置
+     */
+    private static boolean isClassConfig(String path) {
+        return ReUtil.isMatch(CLASS_CONFIG_REGEX, path);
+    }
+
+    /**
+     * 判定是否为zk配置
+     */
+    private static boolean isZKConfig(String path) {
+        return ReUtil.isMatch(FORMATE_XML_CONFIG_REGEX, path)
+                || ReUtil.isMatch(FORMATE_JSON_CONFIG_REGEX, path)
+                || ReUtil.isMatch(FORMATE_YML_CONFIG_REGEX, path);
+    }
+}

--- a/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/LocalParserFactory.java
+++ b/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/LocalParserFactory.java
@@ -1,0 +1,27 @@
+package com.yomahub.liteflow.parser.factory;
+
+import com.yomahub.liteflow.parser.*;
+
+/**
+ * 本地文件
+ * <p>
+ *
+ * @author junjun
+ */
+public class LocalParserFactory implements FlowParserFactory {
+
+    @Override
+    public JsonFlowParser createJsonParser(String path) {
+        return new LocalJsonFlowParser();
+    }
+
+    @Override
+    public XmlFlowParser createXmlParser(String path) {
+        return new LocalXmlFlowParser();
+    }
+
+    @Override
+    public YmlFlowParser createYmlParser(String path) {
+        return new LocalYmlFlowParser();
+    }
+}

--- a/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/ZookeeperParserFactory.java
+++ b/liteflow-core/src/main/java/com/yomahub/liteflow/parser/factory/ZookeeperParserFactory.java
@@ -1,0 +1,28 @@
+package com.yomahub.liteflow.parser.factory;
+
+import com.yomahub.liteflow.parser.*;
+import com.yomahub.liteflow.property.LiteflowConfigGetter;
+
+/**
+ * Class文件
+ * <p>
+ *
+ * @author junjun
+ */
+public class ZookeeperParserFactory implements FlowParserFactory {
+    
+    @Override
+    public JsonFlowParser createJsonParser(String path) {
+        return new ZookeeperJsonFlowParser(LiteflowConfigGetter.get().getZkNode());
+    }
+
+    @Override
+    public XmlFlowParser createXmlParser(String path) {
+        return new ZookeeperXmlFlowParser(LiteflowConfigGetter.get().getZkNode());
+    }
+
+    @Override
+    public YmlFlowParser createYmlParser(String path) {
+        return new ZookeeperYmlFlowParser(LiteflowConfigGetter.get().getZkNode());
+    }
+}

--- a/liteflow-testcase-springboot/src/test/java/com/yomahub/liteflow/test/base/cmp/DCmp.java
+++ b/liteflow-testcase-springboot/src/test/java/com/yomahub/liteflow/test/base/cmp/DCmp.java
@@ -15,7 +15,7 @@ public class DCmp extends NodeComponent {
 
 	@Override
 	public void process() {
-		System.out.println("CCmp executed!");
+		System.out.println("DCmp executed!");
 	}
 
 }

--- a/liteflow-testcase-springboot/src/test/java/com/yomahub/liteflow/test/parsecustom/CustomParserYmlSpringbootTest.java
+++ b/liteflow-testcase-springboot/src/test/java/com/yomahub/liteflow/test/parsecustom/CustomParserYmlSpringbootTest.java
@@ -1,0 +1,41 @@
+package com.yomahub.liteflow.test.parsecustom;
+
+import com.yomahub.liteflow.core.FlowExecutor;
+import com.yomahub.liteflow.flow.LiteflowResponse;
+import com.yomahub.liteflow.slot.DefaultContext;
+import com.yomahub.liteflow.test.BaseTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.annotation.Resource;
+
+/**
+ * springboot环境的自定义yml parser单元测试
+ * 主要测试自定义配置源类是否能引入springboot中的其他依赖
+ * <p>
+ *
+ * @author junjun
+ */
+@RunWith(SpringRunner.class)
+@TestPropertySource(value = "classpath:/parsecustom/application-custom-yml.properties")
+@SpringBootTest(classes = CustomParserYmlSpringbootTest.class)
+@EnableAutoConfiguration
+@ComponentScan({"com.yomahub.liteflow.test.parsecustom.cmp"})
+public class CustomParserYmlSpringbootTest extends BaseTest {
+
+    @Resource
+    private FlowExecutor flowExecutor;
+
+    //测试springboot场景的自定义json parser
+    @Test
+    public void testYmlCustomParser() {
+        LiteflowResponse<DefaultContext> response = flowExecutor.execute2Resp("chain1", "args");
+        Assert.assertTrue(response.isSuccess());
+    }
+}

--- a/liteflow-testcase-springboot/src/test/java/com/yomahub/liteflow/test/parsecustom/parser/CustomYmlFlowParser.java
+++ b/liteflow-testcase-springboot/src/test/java/com/yomahub/liteflow/test/parsecustom/parser/CustomYmlFlowParser.java
@@ -1,0 +1,23 @@
+package com.yomahub.liteflow.test.parsecustom.parser;
+
+import com.yomahub.liteflow.parser.ClassYmlFlowParser;
+
+/**
+ * springboot环境的自定义yml parser单元测试
+ * 主要测试自定义配置源类是否能引入springboot中的其他依赖
+ * <p>
+ *
+ * @author junjun
+ */
+public class CustomYmlFlowParser extends ClassYmlFlowParser {
+
+    @Override
+    public String parseCustom() {
+        return "flow:\n" +
+                "  chain:\n" +
+                "    - name: chain1\n" +
+                "      condition:\n" +
+                "        - type: then\n" +
+                "          value: 'a,b,c'";
+    }
+}

--- a/liteflow-testcase-springboot/src/test/resources/parsecustom/application-custom-yml.properties
+++ b/liteflow-testcase-springboot/src/test/resources/parsecustom/application-custom-yml.properties
@@ -1,0 +1,1 @@
+liteflow.rule-source=com.yomahub.liteflow.test.parsecustom.parser.CustomYmlFlowParser


### PR DESCRIPTION
## 修改描述
- 简单维护一些小问题，包括正则表达式的书写方式，测试类字符串输出错误的问题
- 增加一个测试类，测试自定义类解析yml文件
- 重构了一下查找解析器的代码
## 测试截图
[自定义类-json-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/custom-class-json.png)
[自定义类-xml-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/custom-class-xml.png)
[自定义类-yml-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/custom-class-yml.png)
[本地文件-json-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/local-file-json.png)
[本地文件-xml-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/local-file-xml.png)
[本地文件-yml-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/local-file-yml.png)
[本地文件-springEL-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/local-file-springEL.png)
[zookeeper-json-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/zk-json.png)
[zookeeper-xml-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/zk-xml.png)
[zookeeper-yml-test](https://raw.githubusercontent.com/ContantLearn/image-resource/main/pull-request-images/lite-flow/20220626/zk-yml.png)