### PR TITLE
支持更多数据库布尔类型

### DIFF
--- a/liteflow-rule-plugin/liteflow-rule-sql/src/main/java/com/yomahub/liteflow/parser/sql/read/impl/ChainRead.java
+++ b/liteflow-rule-plugin/liteflow-rule-sql/src/main/java/com/yomahub/liteflow/parser/sql/read/impl/ChainRead.java
@@ -48,9 +48,8 @@ public class ChainRead extends AbstractSqlRead<ChainVO> {
     @Override
     public boolean getEnableFiledValue(ResultSet rs) throws SQLException {
         String chainEnableField = super.config.getChainEnableField();
-        byte enable = rs.getByte(chainEnableField);
 
-        return enable == 1;
+        return rs.getBoolean(chainEnableField);
     }
 
     @Override

--- a/liteflow-rule-plugin/liteflow-rule-sql/src/main/java/com/yomahub/liteflow/parser/sql/read/impl/ScriptRead.java
+++ b/liteflow-rule-plugin/liteflow-rule-sql/src/main/java/com/yomahub/liteflow/parser/sql/read/impl/ScriptRead.java
@@ -48,9 +48,8 @@ public class ScriptRead extends AbstractSqlRead<ScriptVO> {
     @Override
     public boolean getEnableFiledValue(ResultSet rs) throws SQLException {
         String scriptEnableField = super.config.getScriptEnableField();
-        byte enable = rs.getByte(scriptEnableField);
 
-        return enable == 1;
+        return rs.getBoolean(scriptEnableField);;
     }
 
     @Override

--- a/liteflow-rule-plugin/liteflow-rule-sql/src/main/java/com/yomahub/liteflow/parser/sql/read/impl/ScriptRead.java
+++ b/liteflow-rule-plugin/liteflow-rule-sql/src/main/java/com/yomahub/liteflow/parser/sql/read/impl/ScriptRead.java
@@ -49,7 +49,7 @@ public class ScriptRead extends AbstractSqlRead<ScriptVO> {
     public boolean getEnableFiledValue(ResultSet rs) throws SQLException {
         String scriptEnableField = super.config.getScriptEnableField();
 
-        return rs.getBoolean(scriptEnableField);;
+        return rs.getBoolean(scriptEnableField);
     }
 
     @Override


### PR DESCRIPTION
当前enable字段支持判断是否启用的类型过于窄使用jdbc提供的getBoolean能提升更高的类型兼容性
```java
    /**
     * Retrieves the value of the designated column in the current row
     * of this {@code ResultSet} object as
     * a {@code boolean} in the Java programming language.
     *
     * <P>If the designated column has a datatype of CHAR or VARCHAR
     * and contains a "0" or has a datatype of BIT, TINYINT, SMALLINT, INTEGER or BIGINT
     * and contains  a 0, a value of {@code false} is returned.  If the designated column has a datatype
     * of CHAR or VARCHAR
     * and contains a "1" or has a datatype of BIT, TINYINT, SMALLINT, INTEGER or BIGINT
     * and contains  a 1, a value of {@code true} is returned.
     *
     * @param columnLabel the label for the column specified with the SQL AS clause.  If the SQL AS clause was not specified, then the label is the name of the column
     * @return the column value; if the value is SQL {@code NULL}, the
     * value returned is {@code false}
     * @throws SQLException if the columnLabel is not valid;
     * if a database access error occurs or this method is
     *            called on a closed result set
     */
    boolean getBoolean(String columnLabel) throws SQLException;
```